### PR TITLE
Small fixes

### DIFF
--- a/src/Product/DSLRNet.Console/Properties/launchSettings.json
+++ b/src/Product/DSLRNet.Console/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "DSLRNet.Console": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "--rescan"
     }
   }
 }

--- a/src/Product/DSLRNet.Core/DAL/RegulationBinBank.cs
+++ b/src/Product/DSLRNet.Core/DAL/RegulationBinBank.cs
@@ -137,7 +137,7 @@ public class RegulationBinBank
     {
         if (!fileHandler.TryGetFile("regulation.pre-dslr.bin", out string regBinPath))
         {
-            if (fileHandler.TryGetFile("regulation.bin", out regBinPath))
+            if (!fileHandler.TryGetFile("regulation.bin", out regBinPath))
             {
                 regBinPath = Path.Combine(this.settings.GamePath, "regulation.bin");
             }

--- a/src/Product/DSLRNet.Core/Handlers/FileSourceHandler.cs
+++ b/src/Product/DSLRNet.Core/Handlers/FileSourceHandler.cs
@@ -8,11 +8,6 @@ public class FileSourceHandler(IOptions<Settings> settings)
 {
     public bool TryGetFile(string fileName, [NotNullWhen(true)] out string fullPath)
     {
-        if (settings.Value.OrderedModPaths.Count == 0)
-        {
-            throw new InvalidOperationException("Mod paths not set");
-        }
-
         fullPath = string.Empty;
 
         foreach (string path in settings.Value.OrderedModPaths)
@@ -42,11 +37,6 @@ public class FileSourceHandler(IOptions<Settings> settings)
 
     public List<string> ListFilesFromAllModDirectories(string basePath, string filter)
     {
-        if (settings.Value.OrderedModPaths.Count == 0)
-        {
-            throw new InvalidOperationException("Mod paths not set");
-        }
-
         List<string> files = [];
         foreach (string path in settings.Value.OrderedModPaths)
         {


### PR DESCRIPTION
Fixed error where the user does not use the PARSE MODENGINE TOML leading to mod directories not defined error.

Fixed regulation.bin error where a fresh run that doesn't have a pre-dslr file can inadvertently fallback to the game regulation.bin, breaking all other mod directories.